### PR TITLE
Fix -fPIC with Cuda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ build: src/main.cpp .FORCE
 	hipcc src/main.cpp --offload-arch=native -I "$(current_dir)include" -Wno-ignored-attributes -shared -fPIC -o "$(current_dir)hipssimu2$(dllend)"
 
 buildcuda: src/main.cpp .FORCE
-	nvcc -x cu src/main.cpp -arch=native -I "$(current_dir)include" -fPIC -shared -o "$(current_dir)hipssimu2$(dllend)"
+	nvcc -x cu src/main.cpp -arch=native -I "$(current_dir)include" -Xcompiler -fPIC -shared -o "$(current_dir)hipssimu2$(dllend)"
 
 buildcudaall: src/main.cpp .FORCE
-	nvcc -x cu src/main.cpp -arch=all -I "$(current_dir)include" -fPIC -shared -o "$(current_dir)hipssimu2$(dllend)"
+	nvcc -x cu src/main.cpp -arch=all -I "$(current_dir)include" -Xcompiler -fPIC -shared -o "$(current_dir)hipssimu2$(dllend)"
 
 buildall: src/main.cpp .FORCE
 	hipcc src/main.cpp --offload-arch=gfx1100,gfx1101,gfx1102,gfx1030,gfx1031,gfx1032,gfx906,gfx801,gfx802,gfx803 -I "$(current_dir)include" -Wno-ignored-attributes -shared -fPIC -o "$(current_dir)hipssimu2$(dllend)"


### PR DESCRIPTION
Adds -Xcompiler to the Cuda builds, as -fPIC isn't an nvcc option